### PR TITLE
Add support for Oh-my-zsh plugin manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,13 @@ hidden.
 <!-- toc -->
 
 - [Installation](#installation)
-	* [Requirements](#requirements)
-	* [Manual](#manual)
-	* [Package Managers](#package-managers)
+  * [Requirements](#requirements)
+  * [Manual](#manual)
+  * [Package Managers](#package-managers)
+    + [Oh My Zsh](#oh-my-zsh)
 - [Configuration](#configuration)
 - [Usage](#usage)
-	* [Other Usages](#other-usages)
+  * [Other Usages](#other-usages)
 - [Credits](#credits)
 
 <!-- tocstop -->
@@ -52,20 +53,27 @@ source ~/.zsh/zsh-magic-dashboard/magic_dashboard.zsh
 ```
 
 ### Package Managers
-I don't use a package manager, since they [are mostly unnecessary](https://www.youtube.com/watch?v=21_WkzBErQk) and even [increasing zsh loading time considerably](https://blog.jonlu.ca/posts/speeding-up-zsh).
+I don't use a package manager, since they [are mostly unnecessary](https://www.youtube.com/watch?v=21_WkzBErQk)
+and even [increasing zsh loading time considerably](https://blog.jonlu.ca/posts/speeding-up-zsh).
+
 #### Oh My Zsh
 Clone this repository into $ZSH_CUSTOM/plugins (by default ~/.oh-my-zsh/custom/plugins)
+
 ```bash
 git clone https://github.com/chrisgrieser/zsh-magic-dashboard ${ZSH_CUSTOM:-~/.oh-my-zsh/custom}/plugins/zsh-magic-dashboard
 ```
+
 Add the plugin to the list of plugins for Oh My Zsh to load (inside ~/.zshrc):
+
 ```bash
 plugins=( 
     # other plugins...
     zsh-magic-dashboard
 )
 ```
+
 Start a new terminal session.
+
 ```bash
 source ~/.zshrc
 ```

--- a/README.md
+++ b/README.md
@@ -52,14 +52,23 @@ source ~/.zsh/zsh-magic-dashboard/magic_dashboard.zsh
 ```
 
 ### Package Managers
-<!-- vale Google.FirstPerson = NO -->
-I don't use a package manager, since they [are mostly
-unnecessary](https://www.youtube.com/watch?v=21_WkzBErQk) and even [increasing
-zsh loading time considerably](https://blog.jonlu.ca/posts/speeding-up-zsh).
-
-I am open to pull requests adding instructions for package
-managers, though.
-<!-- vale Google.FirstPerson = YES -->
+I don't use a package manager, since they [are mostly unnecessary](https://www.youtube.com/watch?v=21_WkzBErQk) and even [increasing zsh loading time considerably](https://blog.jonlu.ca/posts/speeding-up-zsh).
+#### Oh My Zsh
+Clone this repository into $ZSH_CUSTOM/plugins (by default ~/.oh-my-zsh/custom/plugins)
+```bash
+git clone https://github.com/chrisgrieser/zsh-magic-dashboard ${ZSH_CUSTOM:-~/.oh-my-zsh/custom}/plugins/zsh-magic-dashboard
+```
+Add the plugin to the list of plugins for Oh My Zsh to load (inside ~/.zshrc):
+```bash
+plugins=( 
+    # other plugins...
+    zsh-magic-dashboard
+)
+```
+Start a new terminal session.
+```bash
+source ~/.zshrc
+```
 
 ## Configuration
 Export these variables in your `~/.zshrc`. The values displayed are the default.

--- a/zsh-magic-dashboard.plugin.zsh
+++ b/zsh-magic-dashboard.plugin.zsh
@@ -1,0 +1,1 @@
+source ${0:A:h}/magic_dashboard.zsh


### PR DESCRIPTION
This PR adds support and instructions for installing the zsh-magic-dashboard plugin using Oh My Zsh. The changes are included in the "Package Managers" section of the README for clarity and convenience.

Kindly suggest ways I can improve this PR.